### PR TITLE
Fix Cloud Build logging configuration

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,5 +24,8 @@ steps:
       - '--port'
       - '8080'
 
+options:
+  logging: CLOUD_LOGGING_ONLY
+
 images:
   - gcr.io/$PROJECT_ID/claude-test:$COMMIT_SHA


### PR DESCRIPTION
## Summary
- Add CLOUD_LOGGING_ONLY option to resolve service account logging requirement
- Fixes build error when service account is specified without proper logging configuration

## Changes
- Added `options.logging: CLOUD_LOGGING_ONLY` to cloudbuild.yaml

🤖 Generated with [Claude Code](https://claude.ai/code)