### PR TITLE
Update Cloud Build for Artifact Registry migration

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,11 +1,11 @@
 steps:
   # Build the container image
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/claude-test:$COMMIT_SHA', '.']
+    args: ['build', '-t', 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/claude-test/claude-test:$COMMIT_SHA', '.']
   
-  # Push the container image to Container Registry
+  # Push the container image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'gcr.io/$PROJECT_ID/claude-test:$COMMIT_SHA']
+    args: ['push', 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/claude-test/claude-test:$COMMIT_SHA']
   
   # Deploy container image to Cloud Run
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -15,7 +15,7 @@ steps:
       - 'deploy'
       - 'claude-test'
       - '--image'
-      - 'gcr.io/$PROJECT_ID/claude-test:$COMMIT_SHA'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/claude-test/claude-test:$COMMIT_SHA'
       - '--region'
       - 'asia-northeast1'
       - '--platform'
@@ -28,4 +28,4 @@ options:
   logging: CLOUD_LOGGING_ONLY
 
 images:
-  - gcr.io/$PROJECT_ID/claude-test:$COMMIT_SHA
+  - asia-northeast1-docker.pkg.dev/$PROJECT_ID/claude-test/claude-test:$COMMIT_SHA


### PR DESCRIPTION
## Summary
- Migrate from deprecated Container Registry to Artifact Registry
- Update image paths to use asia-northeast1-docker.pkg.dev
- Fix Cloud Build deployment configuration

## Changes
- Updated all image references from gcr.io to asia-northeast1-docker.pkg.dev
- Changed repository path structure for Artifact Registry

## Prerequisites
- Artifact Registry repository `claude-test` must be created in asia-northeast1

🤖 Generated with [Claude Code](https://claude.ai/code)